### PR TITLE
Neuroglancer 2

### DIFF
--- a/funlib/show/neuroglancer/add_layer.py
+++ b/funlib/show/neuroglancer/add_layer.py
@@ -57,7 +57,9 @@ def add_layer(
     """
 
     is_multiscale = type(array) == list
+
     if not is_multiscale:
+
         a = array if not is_multiscale else array[0]
 
         spatial_dim_names = ["t", "z", "y", "x"]
@@ -68,19 +70,41 @@ def add_layer(
         channel_dims = dims - spatial_dims
 
         attrs = {
-            "names": channel_dim_names[-channel_dims:]
-            if channel_dims > 0
-            else [] + spatial_dim_names[-spatial_dims:],
+            "names": (channel_dim_names[-channel_dims:] if channel_dims > 0 else [])
+            + spatial_dim_names[-spatial_dims:],
             "units": [""] * channel_dims + ["nm"] * spatial_dims,
             "scales": [1] * channel_dims + list(a.voxel_size),
         }
         dimensions = neuroglancer.CoordinateSpace(**attrs)
 
-        voxel_offset = [0] * channel_dims + list(a.roi.get_offset())
-    
+        voxel_offset = [0] * channel_dims + list(a.roi.get_offset() / a.voxel_size)
+
     else:
-        # I'm not sure what needs to be done here!
-        raise Exception("Not Implemented yet!")
+        dimensions = []
+        voxel_offset = None
+        for i, a in enumerate(array):
+
+            if voxel_offset is None:
+                voxel_offset = [0] * channel_dims + list(
+                    a.roi.get_offset() / a.voxel_size
+                )
+
+            spatial_dim_names = ["t", "z", "y", "x"]
+            channel_dim_names = ["b^", "c^"]
+
+            dims = len(a.data.shape)
+            spatial_dims = a.roi.dims()
+            channel_dims = dims - spatial_dims
+
+            attrs = {
+                "names": (channel_dim_names[-channel_dims:] if channel_dims > 0 else [])
+                + spatial_dim_names[-spatial_dims:]
+                if spatial_dims > 0
+                else [],
+                "units": [""] * channel_dims + ["nm"] * spatial_dims,
+                "scales": [1] * channel_dims + list(a.voxel_size),
+            }
+            dimensions.append(neuroglancer.CoordinateSpace(**attrs))
 
     if shader is None:
         a = array if not is_multiscale else array[0]
@@ -88,11 +112,11 @@ def add_layer(
         if dims < len(a.data.shape):
             channels = a.data.shape[0]
             if channels > 1:
-                shader = 'rgb'
+                shader = "rgb"
 
-    if shader == 'rgb':
+    if shader == "rgb":
         if scale_rgb:
-            shader="""
+            shader = """
 void main() {
     emitRGB(
         255.0*vec3(
@@ -100,10 +124,14 @@ void main() {
             toNormalized(getDataValue(%i)),
             toNormalized(getDataValue(%i)))
         );
-}"""%(c[0],c[1],c[2])
+}""" % (
+                c[0],
+                c[1],
+                c[2],
+            )
 
         else:
-            shader="""
+            shader = """
 void main() {
     emitRGB(
         vec3(
@@ -111,26 +139,34 @@ void main() {
             toNormalized(getDataValue(%i)),
             toNormalized(getDataValue(%i)))
         );
-}"""%(c[0],c[1],c[2])
+}""" % (
+                c[0],
+                c[1],
+                c[2],
+            )
 
-    elif shader == 'rgba':
-        shader="""
+    elif shader == "rgba":
+        shader = """
 void main() {
     emitRGBA(
         vec4(
         %f, %f, %f,
         toNormalized(getDataValue()))
         );
-}"""%(h[0], h[1], h[2])
+}""" % (
+            h[0],
+            h[1],
+            h[2],
+        )
 
-    elif shader == 'mask':
-        shader="""
+    elif shader == "mask":
+        shader = """
 void main() {
   emitGrayscale(255.0*toNormalized(getDataValue()));
 }"""
 
-    elif shader == 'heatmap':
-        shader="""
+    elif shader == "heatmap":
+        shader = """
 void main() {
     float v = toNormalized(getDataValue(0));
     vec4 rgba = vec4(0,0,0,0);
@@ -143,35 +179,20 @@ void main() {
     kwargs = {}
 
     if shader is not None:
-        kwargs['shader'] = shader
+        kwargs["shader"] = shader
     if opacity is not None:
-        kwargs['opacity'] = opacity
+        kwargs["opacity"] = opacity
 
     if is_multiscale:
 
-        for v in array:
-            print("voxel size: ", v.voxel_size)
-
-        if reversed_axes:
-
-            layer = ScalePyramid(
-                [
-                    neuroglancer.LocalVolume(
-                        data=v.data,
-                        offset=v.roi.get_offset()[::-1],
-                        voxel_size=v.voxel_size[::-1])
-                    for v in array
-                ])
-        else:
-
-            layer = ScalePyramid(
-                [
-                    neuroglancer.LocalVolume(
-                        data=v.data,
-                        offset=v.roi.get_offset(),
-                        voxel_size=v.voxel_size)
-                    for v in array
-                ])
+        layer = ScalePyramid(
+            [
+                neuroglancer.LocalVolume(
+                    data=v.data, voxel_offset=voxel_offset, dimensions=array_dims
+                )
+                for v, array_dims in zip(array, dimensions)
+            ]
+        )
 
     else:
         layer = neuroglancer.LocalVolume(

--- a/funlib/show/neuroglancer/add_layer.py
+++ b/funlib/show/neuroglancer/add_layer.py
@@ -75,6 +75,8 @@ def add_layer(
             "units": [""] * channel_dims + ["nm"] * spatial_dims,
             "scales": [1] * channel_dims + list(a.voxel_size),
         }
+        if reversed_axes:
+            attrs = {k: v[::-1] for k, v in attrs.items()}
         dimensions = neuroglancer.CoordinateSpace(**attrs)
 
         voxel_offset = [0] * channel_dims + list(a.roi.get_offset() / a.voxel_size)
@@ -104,7 +106,12 @@ def add_layer(
                 "units": [""] * channel_dims + ["nm"] * spatial_dims,
                 "scales": [1] * channel_dims + list(a.voxel_size),
             }
+            if reversed_axes:
+                attrs = {k: v[::-1] for k, v in attrs.items()}
             dimensions.append(neuroglancer.CoordinateSpace(**attrs))
+
+    if reversed_axes:
+        voxel_offset = voxel_offset[::-1]
 
     if shader is None:
         a = array if not is_multiscale else array[0]
@@ -188,9 +195,9 @@ void main() {
         layer = ScalePyramid(
             [
                 neuroglancer.LocalVolume(
-                    data=v.data, voxel_offset=voxel_offset, dimensions=array_dims
+                    data=a.data, voxel_offset=voxel_offset, dimensions=array_dims
                 )
-                for v, array_dims in zip(array, dimensions)
+                for a, array_dims in zip(array, dimensions)
             ]
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-neuroglancer<2
+neuroglancer
 daisy

--- a/scripts/neuroglancer
+++ b/scripts/neuroglancer
@@ -8,6 +8,7 @@ import neuroglancer
 import os
 import webbrowser
 import numpy as np
+import zarr
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -85,7 +86,7 @@ def slice_dataset(a, slices):
     for d, s in list(enumerate(slices))[::-1]:
 
         if isinstance(s, slice):
-            pass
+            raise NotImplementedError("Slicing not yet implemented!")
         else:
             index = (s - a.roi.get_begin()[d])//a.voxel_size[d]
             a.data = Project(a.data, d, index)
@@ -97,10 +98,20 @@ def slice_dataset(a, slices):
     return a
 
 def open_dataset(f, ds):
-
+    original_ds = ds
     ds, slices = parse_ds_name(ds)
+    slices_str = original_ds[len(ds):]
     print("ds    :", ds)
     print("slices:", slices)
+
+    try:
+        dataset_as = []
+        for key in zarr.open(f)[ds].keys():
+            dataset_as.extend(open_dataset(f, f"{ds}/{key}{slices_str}"))
+        return dataset_as
+    except AttributeError as e:
+        # dataset is an array, not a group
+        pass
 
     a = daisy.open_ds(f, ds)
 
@@ -121,7 +132,7 @@ def open_dataset(f, ds):
         print("Converting dtype in memory...")
         a.data = a.data[:].astype(np.uint64)
 
-    return a
+    return [(a, ds)]
 
 for f, datasets in zip(args.file, args.datasets):
 
@@ -130,7 +141,7 @@ for f, datasets in zip(args.file, args.datasets):
         try:
 
             print("Adding %s, %s" % (f, ds))
-            a = open_dataset(f, ds)
+            dataset_as = open_dataset(f, ds)
 
         except Exception as e:
 
@@ -149,10 +160,11 @@ for f, datasets in zip(args.file, args.datasets):
                 open_dataset(f, os.path.relpath(scale_ds, f))
                 for scale_ds in scales
             ]
-        arrays.append(a)
+        for a in dataset_as:
+            arrays.append(a)
 
     with viewer.txn() as s:
-        for array, dataset in zip(arrays, datasets):
+        for array, dataset in arrays:
             try:
                 print(array.roi)
                 print(array.voxel_size)

--- a/scripts/neuroglancer
+++ b/scripts/neuroglancer
@@ -101,11 +101,11 @@ def open_dataset(f, ds):
     original_ds = ds
     ds, slices = parse_ds_name(ds)
     slices_str = original_ds[len(ds):]
-    print("ds    :", ds)
-    print("slices:", slices)
 
     try:
         dataset_as = []
+        if all(key.startswith("s") for key in zarr.open(f)[ds].keys()):
+            raise AttributeError("This group is a multiscale array!")
         for key in zarr.open(f)[ds].keys():
             dataset_as.extend(open_dataset(f, f"{ds}/{key}{slices_str}"))
         return dataset_as
@@ -113,26 +113,37 @@ def open_dataset(f, ds):
         # dataset is an array, not a group
         pass
 
-    a = daisy.open_ds(f, ds)
+    print("ds    :", ds)
+    print("slices:", slices)
+    try:
+        zarr.open(f)[ds].keys()
+        is_multiscale = True
+    except:
+        is_multiscale = False
 
-    if slices is not None:
-        a = slice_dataset(a, slices)
+    if not is_multiscale:
+        a = daisy.open_ds(f, ds)
 
-    if a.roi.dims() == 2:
-        print("ROI is 2D, recruiting next channel to z dimension")
-        a.roi = daisy.Roi((0,) + a.roi.get_begin(), (a.shape[-3],) + a.roi.get_shape())
-        a.voxel_size = daisy.Coordinate((1,) + a.voxel_size)
+        if slices is not None:
+            a = slice_dataset(a, slices)
 
-    if a.roi.dims() == 4:
-        print("ROI is 4D, stripping first dimension and treat as channels")
-        a.roi = daisy.Roi(a.roi.get_begin()[1:], a.roi.get_shape()[1:])
-        a.voxel_size = daisy.Coordinate(a.voxel_size[1:])
+        if a.roi.dims() == 2:
+            print("ROI is 2D, recruiting next channel to z dimension")
+            a.roi = daisy.Roi((0,) + a.roi.get_begin(), (a.shape[-3],) + a.roi.get_shape())
+            a.voxel_size = daisy.Coordinate((1,) + a.voxel_size)
 
-    if a.data.dtype == np.int64 or a.data.dtype == np.int16:
-        print("Converting dtype in memory...")
-        a.data = a.data[:].astype(np.uint64)
+        if a.roi.dims() == 4:
+            print("ROI is 4D, stripping first dimension and treat as channels")
+            a.roi = daisy.Roi(a.roi.get_begin()[1:], a.roi.get_shape()[1:])
+            a.voxel_size = daisy.Coordinate(a.voxel_size[1:])
 
-    return [(a, ds)]
+        if a.data.dtype == np.int64 or a.data.dtype == np.int16:
+            print("Converting dtype in memory...")
+            a.data = a.data[:].astype(np.uint64)
+
+        return [(a, ds)]
+    else:
+        return [([daisy.open_ds(f, f"{ds}/{key}") for key in zarr.open(f)[ds].keys()], ds)]
 
 for f, datasets in zip(args.file, args.datasets):
 
@@ -165,12 +176,6 @@ for f, datasets in zip(args.file, args.datasets):
 
     with viewer.txn() as s:
         for array, dataset in arrays:
-            try:
-                print(array.roi)
-                print(array.voxel_size)
-            except:
-                print(array[0].roi)
-                print(array[0].voxel_size)
             add_layer(s, array, dataset)
 
 if args.graphs:
@@ -190,7 +195,6 @@ if args.graphs:
             if ids is None:
                 ids = range(len(loc))
             for i, l in zip(ids, loc):
-                print(i, l)
                 if dims == 2:
                     l = np.concatenate([[0], l])
                 graph_annotations.append(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
         author_email='funkej@janelia.hhmi.org',
         license='MIT',
         install_requires=[
-            'neuroglancer<2',
+            'neuroglancer',
             'daisy'
         ],
         packages=[


### PR DESCRIPTION
Added neuroglancer2 support.
Sorry @funkey, didn't notice you had already started this on a neuroglancer2 branch when I started. Looks like we did basically the same thing. I also added neuroglancer2 support for multi scale pyramids in `add layer`, so I think `add_layer` is now fully supported in neuroglancer2.

updated the neuroglancer command line script to work with multi scale pyramids (assuming a form of zarr group with arrays s0 - sn).
Added support for visualizing a group with the neuroglancer command. i.e. `neuroglancer --file test.zarr --datasets volumes` will add all arrays in the volumes group recursively to your neuroglancer context.


Not confident that the `reversed_axes` flag is working as expected. If someone wants to take a look at that or point me to a dataset that needs the `reversed_axes` flag I can get it working