### PR TITLE
Fix `dims` syntax when using daisy v2

### DIFF
--- a/funlib/show/neuroglancer/add_layer.py
+++ b/funlib/show/neuroglancer/add_layer.py
@@ -66,7 +66,7 @@ def add_layer(
         channel_dim_names = ["b^", "c^"]
 
         dims = len(a.data.shape)
-        spatial_dims = a.roi.dims()
+        spatial_dims = a.roi.dims
         channel_dims = dims - spatial_dims
 
         attrs = {
@@ -90,7 +90,7 @@ def add_layer(
             channel_dim_names = ["b^", "c^"]
 
             dims = len(a.data.shape)
-            spatial_dims = a.roi.dims()
+            spatial_dims = a.roi.dims
             channel_dims = dims - spatial_dims
 
             attrs = {
@@ -115,7 +115,7 @@ def add_layer(
 
     if shader is None:
         a = array if not is_multiscale else array[0]
-        dims = a.roi.dims()
+        dims = a.roi.dims
         if dims < len(a.data.shape):
             channels = a.data.shape[0]
             if channels > 1:


### PR DESCRIPTION
Daisy v2 made `dims` an attribute instead of a function call. This however required funlib.show.neuroglancer users to also upgrade to the latest `daisy` which has syntax breaking changes so we should also add `daisy>=1` to the requirement?